### PR TITLE
add func to launch browser with persistent context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,13 @@
 # Test binary, built with `go test -c`
 *.test
 
+# browser contexts
+tmp
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.DS_Store

--- a/playwright.go
+++ b/playwright.go
@@ -1,6 +1,7 @@
 package playwright
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -12,20 +13,21 @@ import (
 	"go.k6.io/k6/js/modules"
 )
 
-//Register the extension on module initialization, available to
-//import from JS as "k6/x/playwright".
+// Register the extension on module initialization, available to
+// import from JS as "k6/x/playwright".
 func init() {
 	modules.Register("k6/x/playwright", new(Playwright))
 }
 
-//Playwright is the k6 extension for a playwright-go client.
+// Playwright is the k6 extension for a playwright-go client.
 type Playwright struct {
-	Self    *playwright.Playwright
-	Browser playwright.Browser
-	Page    playwright.Page
+	Self           *playwright.Playwright
+	Browser        playwright.Browser
+	BrowserContext playwright.BrowserContext
+	Page           playwright.Page
 }
 
-//Launch starts the playwright client and launches a browser
+// Launch starts the playwright client and launches a browser
 func (p *Playwright) Launch(args playwright.BrowserTypeLaunchOptions) {
 	pw, err := playwright.Run()
 	if err != nil {
@@ -39,7 +41,21 @@ func (p *Playwright) Launch(args playwright.BrowserTypeLaunchOptions) {
 	p.Browser = browser
 }
 
-//Connect attaches Playwright to an existing browser instance
+// LaunchPersistent starts the playwright client and launches a browser with a persistent context
+func (p *Playwright) LaunchPersistent(dir string, args playwright.BrowserTypeLaunchPersistentContextOptions) {
+	pw, err := playwright.Run()
+	if err != nil {
+		log.Fatalf("could not start playwright: %v", err)
+	}
+	browser, err := pw.Chromium.LaunchPersistentContext(dir, args)
+	if err != nil {
+		log.Fatalf("could not launch browser: %v", err)
+	}
+	p.Self = pw
+	p.BrowserContext = browser
+}
+
+// Connect attaches Playwright to an existing browser instance
 func (p *Playwright) Connect(url string, args playwright.BrowserTypeConnectOverCDPOptions) {
 	pw, err := playwright.Run()
 	if err != nil {
@@ -56,18 +72,18 @@ func (p *Playwright) Connect(url string, args playwright.BrowserTypeConnectOverC
 	p.Page = context.Pages()[0]
 }
 
-//NewPage opens a new page within the browser
+// NewPage opens a new page within the browser
 func (p *Playwright) NewPage() {
-	page, err := p.Browser.NewPage()
+	page, err := p.newPage()
 	if err != nil {
 		log.Fatalf("could not create page: %v", err)
 	}
 	p.Page = page
 }
 
-//Kill closes browser instance and stops puppeteer client
+// Kill closes browser instance and stops puppeteer client
 func (p *Playwright) Kill() {
-	if err := p.Browser.Close(); err != nil {
+	if err := p.closeBrowser(); err != nil {
 		log.Fatalf("could not close browser: %v", err)
 	}
 	if err := p.Self.Stop(); err != nil {
@@ -79,47 +95,47 @@ func (p *Playwright) Kill() {
 //                         ACTIONS
 //---------------------------------------------------------------------
 
-//Goto wrapper around playwright goto page function that takes in a url and a set of options
+// Goto wrapper around playwright goto page function that takes in a url and a set of options
 func (p *Playwright) Goto(url string, opts playwright.PageGotoOptions) {
 	if _, err := p.Page.Goto(url, opts); err != nil {
 		log.Fatalf("could not goto: %v", err)
 	}
 }
 
-//WaitForSelector wrapper around playwright waitForSelector page function that takes in a selector and a set of options
+// WaitForSelector wrapper around playwright waitForSelector page function that takes in a selector and a set of options
 func (p *Playwright) WaitForSelector(selector string, opts playwright.PageWaitForSelectorOptions) {
 	if _, err := p.Page.WaitForSelector(selector, opts); err != nil {
 		log.Fatalf("error with waiting for the selector: %v", err)
 	}
 }
 
-//Click wrapper around playwright click page function that takes in a selector and a set of options
+// Click wrapper around playwright click page function that takes in a selector and a set of options
 func (p *Playwright) Click(selector string, opts playwright.PageClickOptions) {
 	if err := p.Page.Click(selector, opts); err != nil {
 		log.Fatalf("error with clicking: %v", err)
 	}
 }
 
-//Type wrapper around playwright type page function that takes in a selector, string, and a set of options
+// Type wrapper around playwright type page function that takes in a selector, string, and a set of options
 func (p *Playwright) Type(selector string, typedString string, opts playwright.PageTypeOptions) {
 	if err := p.Page.Type(selector, typedString, opts); err != nil {
 		log.Fatalf("error with typing: %v", err)
 	}
 }
 
-//PressKey wrapper around playwright Press page function that takes in a selector, key, and a set of options
+// PressKey wrapper around playwright Press page function that takes in a selector, key, and a set of options
 func (p *Playwright) PressKey(selector string, key string, opts playwright.PagePressOptions) {
 	if err := p.Page.Press(selector, key, opts); err != nil {
 		log.Fatalf("error with pressing the key: %v", err)
 	}
 }
 
-//Sleep wrapper around playwright waitForTimeout page function that sleeps for the given `timeout` in milliseconds
+// Sleep wrapper around playwright waitForTimeout page function that sleeps for the given `timeout` in milliseconds
 func (p *Playwright) Sleep(time float64) {
 	p.Page.WaitForTimeout(time)
 }
 
-//Screenshot wrapper around playwright screenshot page function that attempts to take and save a png image of the current screen.
+// Screenshot wrapper around playwright screenshot page function that attempts to take and save a png image of the current screen.
 func (p *Playwright) Screenshot(filename string, perm fs.FileMode, opts playwright.PageScreenshotOptions) {
 	image, err := p.Page.Screenshot(opts)
 	if err != nil {
@@ -131,50 +147,50 @@ func (p *Playwright) Screenshot(filename string, perm fs.FileMode, opts playwrig
 	}
 }
 
-//Focus wrapper around playwright focus page function that takes in a selector and a set of options
+// Focus wrapper around playwright focus page function that takes in a selector and a set of options
 func (p *Playwright) Focus(selector string, opts playwright.PageFocusOptions) {
 	if err := p.Page.Focus(selector); err != nil {
 		log.Fatalf("error focusing on the element: %v", err)
 	}
 }
 
-//Fill wrapper around playwright fill page function that takes in a selector, text, and a set of options
+// Fill wrapper around playwright fill page function that takes in a selector, text, and a set of options
 func (p *Playwright) Fill(selector string, filledString string, opts playwright.FrameFillOptions) {
 	if err := p.Page.Fill(selector, filledString, opts); err != nil {
 		log.Fatalf("error with fill: %v", err)
 	}
 }
 
-//SelectOptions wrapper around playwright selectOptions page function that takes in a selector, values, and a set of options
+// SelectOptions wrapper around playwright selectOptions page function that takes in a selector, values, and a set of options
 func (p *Playwright) SelectOptions(selector string, values playwright.SelectOptionValues, opts playwright.FrameSelectOptionOptions) {
-	_, err := p.Page.SelectOption(selector, values, opts);
+	_, err := p.Page.SelectOption(selector, values, opts)
 	if err != nil {
 		log.Fatalf("error selecting the option: %v", err)
 	}
 }
 
-//Check wrapper around playwright check page function that takes in a selector and a set of options
-func (p *Playwright) Check(selector string, opts playwright.FrameCheckOptions)  {
+// Check wrapper around playwright check page function that takes in a selector and a set of options
+func (p *Playwright) Check(selector string, opts playwright.FrameCheckOptions) {
 	if err := p.Page.Check(selector, opts); err != nil {
 		log.Fatalf("error with checking the field: %v", err)
 	}
 }
 
-//Uncheck wrapper around playwright uncheck page function that takes in a selector and a set of options
-func (p *Playwright) Uncheck(selector string, opts playwright.FrameUncheckOptions)  {
+// Uncheck wrapper around playwright uncheck page function that takes in a selector and a set of options
+func (p *Playwright) Uncheck(selector string, opts playwright.FrameUncheckOptions) {
 	if err := p.Page.Uncheck(selector, opts); err != nil {
 		log.Fatalf("error with unchecking the field: %v", err)
 	}
 }
 
-//DragAndDrop wrapper around playwright draganddrop page function that takes in two selectors(source and target) and a set of options
+// DragAndDrop wrapper around playwright draganddrop page function that takes in two selectors(source and target) and a set of options
 func (p *Playwright) DragAndDrop(sourceSelector string, targetSelector string, opts playwright.FrameDragAndDropOptions) {
 	if err := p.Page.DragAndDrop(sourceSelector, targetSelector, opts); err != nil {
 		log.Fatalf("error with drag and drop: %v", err)
 	}
 }
 
-//Evaluate wrapper around playwright evaluate page function that takes in an expresion and a set of options and evaluates the expression/function returning the resulting information.
+// Evaluate wrapper around playwright evaluate page function that takes in an expresion and a set of options and evaluates the expression/function returning the resulting information.
 func (p *Playwright) Evaluate(expression string, opts playwright.PageEvaluateOptions) interface{} {
 	returnedValue, err := p.Page.Evaluate(expression, opts)
 	if err != nil {
@@ -183,14 +199,14 @@ func (p *Playwright) Evaluate(expression string, opts playwright.PageEvaluateOpt
 	return returnedValue
 }
 
-//Reload wrapper around playwright reload page function
+// Reload wrapper around playwright reload page function
 func (p *Playwright) Reload() {
 	if _, err := p.Page.Reload(); err != nil {
 		log.Fatalf("error with reloading the page: %v", err)
 	}
 }
 
-//FirstPaint function that gathers the Real User Monitoring Metrics for First Paint of the current page
+// FirstPaint function that gathers the Real User Monitoring Metrics for First Paint of the current page
 func (p *Playwright) FirstPaint() uint64 {
 	entries, err := p.Page.Evaluate("JSON.stringify(performance.getEntriesByName('first-paint'))")
 	if err != nil {
@@ -200,7 +216,7 @@ func (p *Playwright) FirstPaint() uint64 {
 	return gjson.Get(entriesToString, "0.startTime").Uint()
 }
 
-//FirstContentfulPaint function that gathers the Real User Monitoring Metrics for First Contentful Paint of the current page
+// FirstContentfulPaint function that gathers the Real User Monitoring Metrics for First Contentful Paint of the current page
 func (p *Playwright) FirstContentfulPaint() uint64 {
 	entries, err := p.Page.Evaluate("JSON.stringify(performance.getEntriesByName('first-contentful-paint'))")
 	if err != nil {
@@ -210,7 +226,7 @@ func (p *Playwright) FirstContentfulPaint() uint64 {
 	return gjson.Get(entriesToString, "0.startTime").Uint()
 }
 
-//TimeToMinimallyInteractive function that gathers the Real User Monitoring Metrics for Time to Minimally Interactive of the current page (based on the first input)
+// TimeToMinimallyInteractive function that gathers the Real User Monitoring Metrics for Time to Minimally Interactive of the current page (based on the first input)
 func (p *Playwright) TimeToMinimallyInteractive() uint64 {
 	entries, err := p.Page.Evaluate("JSON.stringify(performance.getEntriesByType('first-input'))")
 	if err != nil {
@@ -220,7 +236,7 @@ func (p *Playwright) TimeToMinimallyInteractive() uint64 {
 	return gjson.Get(entriesToString, "0.startTime").Uint()
 }
 
-//FirstInputDelay function that gathers the Real User Monitoring Metrics for First Input Delay of the current page
+// FirstInputDelay function that gathers the Real User Monitoring Metrics for First Input Delay of the current page
 func (p *Playwright) FirstInputDelay() uint64 {
 	entries, err := p.Page.Evaluate("JSON.stringify(performance.getEntriesByType('first-input'))")
 	if err != nil {
@@ -230,40 +246,48 @@ func (p *Playwright) FirstInputDelay() uint64 {
 	return gjson.Get(entriesToString, "0.processingStart").Uint() - gjson.Get(entriesToString, "0.startTime").Uint() //https://web.dev/fid/  for calc
 }
 
-//Cookies wrapper around playwright cookies fetch function
+// Cookies wrapper around playwright cookies fetch function
 func (p *Playwright) Cookies() []*playwright.BrowserContextCookiesResult {
-	if p.Browser == nil {
-		log.Fatalf("looks like there's no browser attached. please call `launch()` before accessing the cookies.")
-	}
-
-	if len(p.Browser.Contexts()) == 0 {
-		log.Fatalf("looks like there's no browser contexts are attached. please use `goto()` before accessing the cookies.")
-	}
-
-	cookies, err := p.Browser.Contexts()[0].Cookies()
+	cookies, err := p.cookies()
 	if err != nil {
-		log.Fatalf("error with getting the cookies from the default context: %v", err)
+		log.Fatalf("error with getting the cookies: %v", err)
 	}
 	return cookies
 }
 
+//---------------------------------------------------------------------
+//                         Helpers
+//---------------------------------------------------------------------
 
-/*
-type resource struct {
-	name string
-	size int
-	time int
-}
-
-func (p *Playwright) PageResourceMetrics() []resource {
-	var resources []resource
-	entries, err := p.Page.Evaluate("JSON.stringify(window.performance.getEntries)")
-	if err != nil {
-		log.Fatalf("error with getting the window performance entries for page resource metrics: %v", err)
+// newPage creates a new page and returns it either with or without a context
+func (p *Playwright) newPage() (playwright.Page, error) {
+	if p.Browser != nil {
+		return p.Browser.NewPage()
 	}
-	entriesToString := fmt.Sprintf("%v", entries)
-	fmt.Println(entriesToString)
-	//resource := resouce{}
-	return resources
+	if p.BrowserContext != nil {
+		return p.BrowserContext.NewPage()
+	}
+	return nil, errors.New("no browser or browser context attached")
 }
-*/
+
+// closeBrowser closes the browser and the browser context
+func (p *Playwright) closeBrowser() error {
+	if p.Browser != nil {
+		return p.Browser.Close()
+	}
+	if p.BrowserContext != nil {
+		return p.BrowserContext.Close()
+	}
+	return errors.New("no browser or browser context attached")
+}
+
+// cookies returns the cookies from the browser context or from browser persistent context
+func (p *Playwright) cookies() ([]*playwright.BrowserContextCookiesResult, error) {
+	if p.Browser != nil && len(p.Browser.Contexts()) > 0 {
+		return p.Browser.Contexts()[0].Cookies()
+	}
+	if p.BrowserContext != nil {
+		return p.BrowserContext.Cookies()
+	}
+	return nil, errors.New("no browser or browser context attached")
+}

--- a/playwright_test.go
+++ b/playwright_test.go
@@ -2,6 +2,7 @@ package playwright
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 
@@ -12,6 +13,7 @@ var tests = []func(t *testing.T){
 	TestPlaywright,
 	TestPlaywright2,
 	TestCookies,
+	TestPersistentContext,
 }
 
 func TestPlaywright(t *testing.T) {
@@ -25,8 +27,8 @@ func TestPlaywright(t *testing.T) {
 
 	pw.Launch(opts)
 	pw.NewPage()
-	pw.Goto("https://www.google.com", opts2)
-	pw.WaitForSelector("input[title='Search']", opts3)
+	pw.Goto("https://www.github.com", opts2)
+	pw.WaitForSelector("input[name='q']", opts3)
 	pw.Kill()
 }
 
@@ -42,9 +44,9 @@ func TestPlaywright2(t *testing.T) {
 
 	pw.Launch(opts)
 	pw.NewPage()
-	pw.Goto("https://www.google.com", opts2)
-	pw.WaitForSelector("input[title='Search']", opts3)
-	pw.Type("input[title='Search']", "how to measure real user metrics with the xk6-playwright extension for k6?", opts4)
+	pw.Goto("https://www.github.com", opts2)
+	pw.WaitForSelector("input[name='q']", opts3)
+	pw.Type("input[name='q']", "how to measure real user metrics with the xk6-playwright extension for k6?", opts4)
 	fp := pw.FirstPaint()
 	fcp := pw.FirstContentfulPaint()
 	ttmi := pw.TimeToMinimallyInteractive()
@@ -63,6 +65,22 @@ func TestPlaywright3(t *testing.T) {
 
 	pw.Connect("http://localhost:9222", opts)
 	pw.Goto("https://www.unqork.com", opts2)
+}
+
+func TestPersistentContext(t *testing.T) {
+	var pw Playwright
+	headless := true
+	opts := playwright.BrowserTypeLaunchPersistentContextOptions{
+		Headless: &headless,
+	}
+	var opts2 playwright.PageGotoOptions
+	var opts3 playwright.PageWaitForSelectorOptions
+
+	pw.LaunchPersistent("./tmp/context-"+strconv.Itoa(rand.Intn(1000)), opts)
+	pw.NewPage()
+	pw.Goto("https://www.github.com", opts2)
+	pw.WaitForSelector("input[name='q']", opts3)
+	pw.Kill()
 }
 
 func TestCookies(t *testing.T) {


### PR DESCRIPTION
## What is this update include

- add func `LaunchPersistent` to launch a browser with persistent context
- add `BrowserContext` field to `Playwright` struct to support persistent context
- add a few helpers to work with both options available now: browser and browserContext

## Rationale

Some auth flows may be a bit complicated to implement in k6 script. So it is possible to use full playwright API to make all interactions before running performance scripts and save the browser context. And then just use this context in k6 script.